### PR TITLE
Support CK Editor

### DIFF
--- a/app/views/rails_admin/main/_form_ck_editorml.html.haml
+++ b/app/views/rails_admin/main/_form_ck_editorml.html.haml
@@ -1,0 +1,10 @@
+:ruby
+  js_data = {
+    jspath: field.location ? field.location : field.base_location + "ckeditor.js",
+    base_location: field.base_location,
+    options: {
+      customConfig: field.config_js ? field.config_js : field.base_location + "config.js"
+    }
+  }
+
+= render 'form', form: form, field: field, field_type: :text_area, html_attributes: field.html_attributes.reverse_merge(data: { richtext: 'ckeditor', options: js_data.to_json })

--- a/lib/rails_admin_hstore_translate/version.rb
+++ b/lib/rails_admin_hstore_translate/version.rb
@@ -1,3 +1,3 @@
 module RailsAdminHstoreTranslate
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Adds support for CK Editor. 

Currently the gem lacks the partial but doesn't remove a fieldtype for ckeditor which causes an app to break.